### PR TITLE
Fix computation of error scores

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -51,15 +51,13 @@ def get_err_scores(test_res, val_res):
 
     n_err_mid, n_err_iqr = get_err_median_and_iqr(test_predict, test_gt)
 
-    test_delta = np.subtract(
+    test_delta = np.abs(np.subtract(
                         np.array(test_predict).astype(np.float64), 
                         np.array(test_gt).astype(np.float64)
-                    )
+                    ))
     epsilon=1e-2
 
-
     err_scores = (test_delta - n_err_mid) / ( np.abs(n_err_iqr) +epsilon)
-    err_scores = np.abs(err_scores)
 
     smoothed_err_scores = np.zeros(err_scores.shape)
     before_num = 3

--- a/util/data.py
+++ b/util/data.py
@@ -74,7 +74,7 @@ def eval_mseloss(predicted, ground_truth):
 
 def get_err_median_and_iqr(predicted, groundtruth):
 
-    np_arr = np.subtract(np.array(predicted), np.array(groundtruth))
+    np_arr = np.abs(np.subtract(np.array(predicted), np.array(groundtruth)))
 
     err_median = np.median(np_arr)
     err_iqr = iqr(np_arr)
@@ -83,7 +83,7 @@ def get_err_median_and_iqr(predicted, groundtruth):
 
 def get_err_median_and_quantile(predicted, groundtruth, percentage):
 
-    np_arr = np.subtract(np.array(predicted), np.array(groundtruth))
+    np_arr = np.abs(np.subtract(np.array(predicted), np.array(groundtruth)))
 
     err_median = np.median(np_arr)
     # err_iqr = iqr(np_arr)
@@ -93,7 +93,7 @@ def get_err_median_and_quantile(predicted, groundtruth, percentage):
 
 def get_err_mean_and_quantile(predicted, groundtruth, percentage):
 
-    np_arr = np.subtract(np.array(predicted), np.array(groundtruth))
+    np_arr = np.abs(np.subtract(np.array(predicted), np.array(groundtruth)))
 
     err_median = trim_mean(np_arr, percentage)
     # err_iqr = iqr(np_arr)
@@ -103,7 +103,7 @@ def get_err_mean_and_quantile(predicted, groundtruth, percentage):
 
 def get_err_mean_and_std(predicted, groundtruth):
 
-    np_arr = np.subtract(np.array(predicted), np.array(groundtruth))
+    np_arr = np.abs(np.subtract(np.array(predicted), np.array(groundtruth)))
 
     err_mean = np.mean(np_arr)
     err_std = np.std(np_arr)


### PR DESCRIPTION
I think the computation of the deviation scores was not correct -- we should take the absolute value of the differences **before** computing the median / IQR of the errors. I've made the corresponding changes to `evaluate.py` and `util/data.py`. 

Is my thinking correct?

Thanks and best regards,

Daniel